### PR TITLE
Enable quoting of all identifiers by default

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -222,6 +222,12 @@ public class FastBootMetadataBuilder {
             LOG.definingFlushBeforeCompletionIgnoredInHem(Environment.FLUSH_BEFORE_COMPLETION);
         }
 
+        // Make sure to quote all identifiers (e.g. prevent casing issues on PostgreSQL) by default:
+        if (!mergedSettings.configurationValues.containsKey(org.hibernate.cfg.AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS)) {
+            mergedSettings.configurationValues.put(org.hibernate.cfg.AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS,
+                    Boolean.TRUE);
+        }
+
         // Quarkus specific
 
         mergedSettings.configurationValues.put("hibernate.temp.use_jdbc_metadata_defaults", "false");


### PR DESCRIPTION
@FroMage  what wou you think of this approach? cc/ @gsmet

On the upside it will consistently create/update the table names...

but I don't think you'll be able to use the import.sql as easily anymore; maybe that's ok and we switch to the Flyway approach :)
Writing SQL directly in the DB also becomes a bit messy, you'll have to be identifiers consistently.

# DO NOT MERGE