### PR TITLE
ORM tenancy tests

### DIFF
--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
 # Necessary because we're creating datasources dynamically,
 # which means the extension can't rely on a static datasource to guess the dialect
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
 # We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
@@ -12,7 +12,7 @@ quarkus.datasource.devservices.enabled=false
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".database.generation=none
 quarkus.hibernate-orm."inventory".multitenant=database
-quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB106Dialect
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm."inventory".packages=io.quarkus.it.hibernate.multitenancy.inventory
 
 #mariadb.base_url is set through Maven config

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
 # Necessary because we're creating datasources dynamically,
 # which means the extension can't rely on a static datasource to guess the dialect
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
 # We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
@@ -12,7 +12,7 @@ quarkus.datasource.devservices.enabled=false
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".database.generation=none
 quarkus.hibernate-orm."inventory".multitenant=database
-quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB106Dialect
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm."inventory".packages=io.quarkus.it.hibernate.multitenancy.inventory
 
 #mariadb.base_url is set through Maven config

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -195,8 +195,8 @@
                 <module>hibernate-search-orm-elasticsearch-coordination-outbox-polling</module>
                 <module>hibernate-search-orm-opensearch</module>
                 <module>hibernate-search-orm-elasticsearch-tenancy</module>
-                <!--
                 <module>hibernate-orm-tenancy</module>
+                <!--
                 <module>hibernate-orm-envers</module>
                 -->
                 <module>vertx-http</module>


### PR DESCRIPTION
Besides the warnings for deprecated dialects - replaced in this PR, there are also complains like:
```
2023-02-17 16:51:09,640 INFO  [org.hib.boo.bea.TypeSafeActivator] (JPA Startup Thread: inventory) Error calling `jakarta.validation.Validation#buildDefaultValidatorFactory`: jakarta.validation.NoProviderFoundException: Unable to create a Configuration, because no Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
	at jakarta.validation.Validation$GenericBootstrapImpl.configure(Validation.java:291)
	at jakarta.validation.Validation.buildDefaultValidatorFactory(Validation.java:103)
	at org.hibernate.boot.beanvalidation.TypeSafeActivator.getValidatorFactory(TypeSafeActivator.java:483)
	at org.hibernate.boot.beanvalidation.TypeSafeActivator.activate(TypeSafeActivator.java:83)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.hibernate.boot.beanvalidation.BeanValidationIntegrator.integrate(BeanValidationIntegrator.java:140)
	at org.hibernate.internal.SessionFactoryImpl.integrate(SessionFactoryImpl.java:451)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:247)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:200)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:78)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:73)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:167)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:68)
	at java.base/java.lang.Thread.run(Thread.java:833)

```
But I suspect that that's expected as 
```xml
<dependency>
    <groupId>io.quarkus</groupId>
    <artifactId>quarkus-hibernate-validator</artifactId>
</dependency>
```
is not among dependencies... Other than that:
```bash
 mvn clean install -Dtest-containers -Dstart-containers -pl :quarkus-integration-test-hibernate-orm-tenancy-schema,:quarkus-integration-test-hibernate-orm-tenancy-datasource,:quarkus-integration-test-hibernate-orm-tenancy-connection-resolver-legacy-qualifiers,:quarkus-integration-test-hibernate-orm-tenancy-connection-resolver


[INFO] Reactor Summary for Quarkus - Integration Tests - Hibernate - Tenancy - Datasource 999-SNAPSHOT:
[INFO] 
[INFO] Quarkus - Integration Tests - Hibernate - Tenancy - Datasource SUCCESS [ 14.153 s]
[INFO] Quarkus - Integration Tests - Hibernate - Tenancy - Connection SUCCESS [ 11.877 s]
[INFO] Quarkus - Integration Tests - Hibernate - Tenancy - Schema SUCCESS [ 12.732 s]
[INFO] Quarkus - Integration Tests - Hibernate - Tenancy - Connection SUCCESS [ 11.668 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```
One "problem" is that `quarkus-integration-test-hibernate-orm-tenancy` doesn't clean up after running tests